### PR TITLE
feat: add secrets.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,5 @@ cython_debug/
 # End of https://www.toptal.com/developers/gitignore/api/django
 
 memo.yaml
-.editorconfig
 .DS_Store
-.json
+secrets.yml

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 omh-app
 
+![Untitled Diagram drawio](https://user-images.githubusercontent.com/32637762/151787896-09a33f94-3a13-4c26-a622-1782d30943e6.png)
+
 医療現場で使えるアプリ。
 
 # DEMO
@@ -46,6 +48,14 @@ docker compose up
 # Note
 
 注意点
+
+## secrets.yml
+
+```yml
+env_variables:
+  Debug: True
+  SECRET_PASSWORD: xxxxxxxxxxx
+```
 
 # Author
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ docker compose up
 
 ## secrets.yml
 
+下記のようなYAMLファイルを用意してください。
+
 ```yml
 env_variables:
   Debug: True

--- a/app.yaml
+++ b/app.yaml
@@ -11,3 +11,6 @@ handlers:
   - url: .*
     secure: always
     script: auto
+
+includes:
+  - secrets.yml


### PR DESCRIPTION
## Describe the PR

To close #40 

CloudSQLの接続情報など、他者に公開すべきでない情報を安全にGAEへデプロイできるようにする。

## Screenshots

<img width="3200" alt="Screen Shot 2022-01-31 at 20 52 27" src="https://user-images.githubusercontent.com/32637762/151789254-4b8bb8d1-906f-4228-b229-e02814f8526c.png">

## Detail of the change

- [x] Prepare `secrets.yml`
- [x] Include `secrets.yml` from `app.ayml`
- [x] Append `secrets.yml` to `.gitignore`

## Anticipated impacts

None.

## To reproduce

Steps to check the behavior:

1. `secrets.yml` を手元で用意する
1. デプロイする
1. `secrets.yml` に書いてある情報がGAE上で環境変数にセットされていることを確認する

## Appendix

参考にした記事。

- [Qiita - GAE で秘匿したい環境変数を安全に設定する](https://qiita.com/nirasan/items/9527ffa7d2f2fac2933e)