### PR TITLE
feat: docker-compose.yml内のjson keyのPATHを変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,6 @@ services:
             "-instances=myapp-omh:us-central1:omh-app-test=tcp:0.0.0.0:3306",
             "-credential_file=/config/myapp-omh-b44933797972.json"]
         volumes:
-            - "/Users/tatsuro/Library/Mobile Documents/com~apple~CloudDocs/omh-app/myapp-omh-b44933797972.json:/config/myapp-omh-b44933797972.json"
+            - ".:/config/"
         ports:
             - "3306:3306"


### PR DESCRIPTION
## Describe the PR

To close #43 

共有したjson keyを `docker-compose.yml` で読み込めたら成功

## Screenshots

<img width="793" alt="image" src="https://user-images.githubusercontent.com/61369434/152634818-cb73a631-75c0-4399-8da3-7713edfb7c17.png">

## Detail of the change

PATHを自分のPCのPATHから `.` に変更

## Anticipated impacts

none

## To reproduce

Steps to check the behavior:

1. `.json` をOMH-APPフォルダに追加
2. `docker-compose up`
3. `.json` を削除
